### PR TITLE
Add support for alphanumeric CNPJ (IN RFB 2.229/2024)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ go get github.com/flavioltonon/go-brazil
 In general, the lib usage involves the generation and evaluation of brazilian document numbers and other brazilian patterns, such as mobile numbers.
 Here are the documents/patterns which have been contemplated so far:
 
-- **CNPJ (Cadastro Nacional de Pessoas Jurídicas)**
+- **CNPJ (Cadastro Nacional de Pessoas Jurídicas)** - including the alphanumeric format introduced by IN RFB n° 2.229/2024, via `ParseAlphanumericCNPJ` (positions 0-11 accept `0-9`/`A-Z`, check digits remain numeric; legacy numeric CNPJs are also accepted)
 - **CPF (Cadastro de Pessoas Físicas)**
 - **Título de Eleitor**
 - **PIS**

--- a/cnpj_alphanumeric.go
+++ b/cnpj_alphanumeric.go
@@ -1,0 +1,122 @@
+package brazil
+
+import (
+	"math/rand"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ParseAlphanumericCNPJ validates CNPJ numbers in the alphanumeric format
+// introduced by IN RFB n° 2.229/2024: positions 0-11 accept 0-9 or A-Z and
+// the check digits (positions 12-13) remain numeric. Legacy numeric CNPJ
+// numbers are also accepted. Lowercase letters are normalized to uppercase.
+func ParseAlphanumericCNPJ(number string) (cnpj, error) {
+	number = strings.ToUpper(regexp.MustCompile(`[./-]`).ReplaceAllString(number, ""))
+
+	if len(number) != 14 {
+		return cnpj{}, ErrIncorrectLenghtCNPJNumber
+	}
+
+	if !regexp.MustCompile(`^[0-9A-Z]{12}[0-9]{2}$`).MatchString(number) {
+		return cnpj{}, ErrInvalidCNPJCharacter
+	}
+
+	if strings.Count(number, string(number[0])) == 14 {
+		return cnpj{}, ErrRepeatedCNPJNumber
+	}
+
+	cnpjNumber := cnpjNumber(number)
+
+	if !cnpjNumber.hasValidAlphanumericFirstDigit() {
+		return cnpj{}, ErrInvalidCNPJFirstDigit
+	}
+
+	if !cnpjNumber.hasValidAlphanumericSecondDigit() {
+		return cnpj{}, ErrInvalidCNPJSecondDigit
+	}
+
+	return cnpj{
+		number: cnpjNumber,
+		valid:  true,
+	}, nil
+}
+
+func RandomAlphanumericCNPJNumber(mask bool) string {
+	var multipliers = []int{6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2}
+	const charset = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+	source := rand.NewSource(time.Now().UnixNano())
+	r := rand.New(source)
+	base := make([]byte, 12)
+	for i := range base {
+		base[i] = charset[r.Intn(len(charset))]
+	}
+	cnpjString := string(base)
+
+	// Calculate first digit
+	sum := 0
+	for i := 0; i < 12; i++ {
+		sum += alphanumericCharValue(cnpjString[i]) * multipliers[i+1]
+	}
+	firstDigit := 0
+	if sum%11 >= 2 {
+		firstDigit = 11 - sum%11
+	}
+
+	// Calculate second digit
+	sum = 0
+	for i := 0; i < 12; i++ {
+		sum += alphanumericCharValue(cnpjString[i]) * multipliers[i]
+	}
+	sum += firstDigit * multipliers[12]
+	secondDigit := 0
+	if sum%11 >= 2 {
+		secondDigit = 11 - sum%11
+	}
+
+	if mask {
+		return cnpjString[:2] + "." + cnpjString[2:5] + "." + cnpjString[5:8] + "/" + cnpjString[8:12] + "-" + strconv.Itoa(firstDigit) + strconv.Itoa(secondDigit)
+	}
+	return cnpjString + strconv.Itoa(firstDigit) + strconv.Itoa(secondDigit)
+}
+
+// alphanumericCharValue converts a CNPJ character to its check digit value
+// as defined by IN RFB n° 2.229/2024: value = ASCII(char) - 48, so that
+// '0'-'9' map to 0-9 and 'A'-'Z' map to 17-42.
+func alphanumericCharValue(c byte) int {
+	return int(c) - 48
+}
+
+func (c cnpjNumber) hasValidAlphanumericFirstDigit() bool {
+	var (
+		multipliers = []int{5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2}
+		sum         int
+	)
+
+	for i := 0; i < 12; i++ {
+		sum += alphanumericCharValue(c[i]) * multipliers[i]
+	}
+	if sum%11 < 2 {
+		return string(c[12]) == strconv.Itoa(0)
+	}
+
+	return string(c[12]) == strconv.Itoa(11-sum%11)
+}
+
+func (c cnpjNumber) hasValidAlphanumericSecondDigit() bool {
+	var (
+		multipliers = []int{6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2}
+		sum         int
+	)
+
+	for i := 0; i < 13; i++ {
+		sum += alphanumericCharValue(c[i]) * multipliers[i]
+	}
+
+	if sum%11 < 2 {
+		return string(c[13]) == strconv.Itoa(0)
+	}
+	return string(c[13]) == strconv.Itoa(11-sum%11)
+}

--- a/cnpj_alphanumeric_test.go
+++ b/cnpj_alphanumeric_test.go
@@ -1,0 +1,190 @@
+package brazil_test
+
+import (
+	"testing"
+
+	. "github.com/flavioltonon/go-brazil"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestParseAlphanumericCNPJ(t *testing.T) {
+	Convey("Given a string named s", t, func() {
+		var s string
+
+		Convey("If s is empty", func() {
+			s = ""
+
+			Convey("And the function ParseAlphanumericCNPJ is called using it as an argument", func() {
+				cnpj, err := ParseAlphanumericCNPJ(s)
+
+				Convey("It should return an error", func() {
+					So(err, ShouldEqual, ErrIncorrectLenghtCNPJNumber)
+
+					Convey("And the CNPJ struct number should be empty", func() {
+						So(cnpj.Number(false), ShouldEqual, "")
+					})
+				})
+			})
+		})
+
+		Convey("If s is a valid alphanumeric CNPJ number", func() {
+			s = "12ABC345000188"
+
+			Convey("And the function ParseAlphanumericCNPJ is called using it as an argument", func() {
+				cnpj, err := ParseAlphanumericCNPJ(s)
+
+				Convey("It should not return an error", func() {
+					So(err, ShouldEqual, nil)
+
+					Convey("And the CNPJ struct number should exist", func() {
+						So(cnpj.Number(false), ShouldEqual, "12ABC345000188")
+						So(cnpj.Number(true), ShouldEqual, "12.ABC.345/0001-88")
+					})
+				})
+			})
+		})
+
+		Convey("If s is a valid masked alphanumeric CNPJ number", func() {
+			s = "12.ABC.345/0001-88"
+
+			Convey("And the function ParseAlphanumericCNPJ is called using it as an argument", func() {
+				cnpj, err := ParseAlphanumericCNPJ(s)
+
+				Convey("It should not return an error", func() {
+					So(err, ShouldEqual, nil)
+
+					Convey("And the CNPJ struct number should exist", func() {
+						So(cnpj.Number(false), ShouldEqual, "12ABC345000188")
+						So(cnpj.Number(true), ShouldEqual, "12.ABC.345/0001-88")
+					})
+				})
+			})
+		})
+
+		Convey("If s is a valid alphanumeric CNPJ number with lowercase letters", func() {
+			s = "12abc345000188"
+
+			Convey("And the function ParseAlphanumericCNPJ is called using it as an argument", func() {
+				cnpj, err := ParseAlphanumericCNPJ(s)
+
+				Convey("It should not return an error", func() {
+					So(err, ShouldEqual, nil)
+
+					Convey("And the CNPJ struct number should be normalized to uppercase", func() {
+						So(cnpj.Number(false), ShouldEqual, "12ABC345000188")
+					})
+				})
+			})
+		})
+
+		Convey("If s is a valid legacy numeric CNPJ number", func() {
+			s = "12345678000195"
+
+			Convey("And the function ParseAlphanumericCNPJ is called using it as an argument", func() {
+				cnpj, err := ParseAlphanumericCNPJ(s)
+
+				Convey("It should not return an error", func() {
+					So(err, ShouldEqual, nil)
+
+					Convey("And the CNPJ struct number should exist", func() {
+						So(cnpj.Number(false), ShouldEqual, "12345678000195")
+						So(cnpj.Number(true), ShouldEqual, "12.345.678/0001-95")
+					})
+				})
+			})
+		})
+
+		Convey("If s is an alphanumeric CNPJ number with invalid check digits", func() {
+			s = "12ABC345000100"
+
+			Convey("And the function ParseAlphanumericCNPJ is called using it as an argument", func() {
+				cnpj, err := ParseAlphanumericCNPJ(s)
+
+				Convey("It should return an error", func() {
+					So(err, ShouldEqual, ErrInvalidCNPJFirstDigit)
+
+					Convey("And the CNPJ struct number should be empty", func() {
+						So(cnpj.Number(false), ShouldEqual, "")
+					})
+				})
+			})
+		})
+
+		Convey("If s is a CNPJ number with all characters equal", func() {
+			s = "00000000000000"
+
+			Convey("And the function ParseAlphanumericCNPJ is called using it as an argument", func() {
+				cnpj, err := ParseAlphanumericCNPJ(s)
+
+				Convey("It should return an error", func() {
+					So(err, ShouldEqual, ErrRepeatedCNPJNumber)
+
+					Convey("And the CNPJ struct number should be empty", func() {
+						So(cnpj.Number(false), ShouldEqual, "")
+					})
+				})
+			})
+		})
+
+		Convey("If s is a CNPJ number with an illegal character", func() {
+			s = "12@BC345000188"
+
+			Convey("And the function ParseAlphanumericCNPJ is called using it as an argument", func() {
+				cnpj, err := ParseAlphanumericCNPJ(s)
+
+				Convey("It should return an error", func() {
+					So(err, ShouldEqual, ErrInvalidCNPJCharacter)
+
+					Convey("And the CNPJ struct number should be empty", func() {
+						So(cnpj.Number(false), ShouldEqual, "")
+					})
+				})
+			})
+		})
+
+		Convey("If s is a CNPJ number with a letter in the check digit positions", func() {
+			s = "12ABC3450001A8"
+
+			Convey("And the function ParseAlphanumericCNPJ is called using it as an argument", func() {
+				cnpj, err := ParseAlphanumericCNPJ(s)
+
+				Convey("It should return an error", func() {
+					So(err, ShouldEqual, ErrInvalidCNPJCharacter)
+
+					Convey("And the CNPJ struct number should be empty", func() {
+						So(cnpj.Number(false), ShouldEqual, "")
+					})
+				})
+			})
+		})
+	})
+}
+
+func TestRandomAlphanumericCNPJNumber(t *testing.T) {
+	Convey("Given the function RandomAlphanumericCNPJNumber", t, func() {
+		Convey("If its mask argument equals true", func() {
+			number := RandomAlphanumericCNPJNumber(true)
+
+			Convey("It should return a valid alphanumeric CNPJ number", func() {
+				cnpj, err := ParseAlphanumericCNPJ(number)
+
+				So(err, ShouldEqual, nil)
+				So(cnpj.Number(false), ShouldNotEqual, "")
+				So(cnpj.Number(true), ShouldNotEqual, "")
+			})
+		})
+
+		Convey("If its mask argument equals false", func() {
+			number := RandomAlphanumericCNPJNumber(false)
+
+			Convey("It should return a valid alphanumeric CNPJ number", func() {
+				cnpj, err := ParseAlphanumericCNPJ(number)
+
+				So(err, ShouldEqual, nil)
+				So(cnpj.Number(false), ShouldNotEqual, "")
+				So(cnpj.Number(true), ShouldNotEqual, "")
+			})
+		})
+	})
+}

--- a/errors.go
+++ b/errors.go
@@ -11,6 +11,8 @@ var (
 	ErrIncorrectLenghtCNPJNumber = errors.New("CNPJ numbers must contain 14 numbers")
 	ErrInvalidCNPJFirstDigit     = errors.New("CNPJ number first digit input is not valid")
 	ErrInvalidCNPJSecondDigit    = errors.New("CNPJ number second digit input is not valid")
+	ErrInvalidCNPJCharacter      = errors.New("CNPJ numbers must contain only characters 0-9 or A-Z in the first 12 positions and 0-9 in the check digits")
+	ErrRepeatedCNPJNumber        = errors.New("CNPJ numbers must not have all characters equal")
 
 	ErrIncorrectLenghtCPFNumber = errors.New("CPF numbers must contain 11 numbers")
 	ErrInvalidCPFNumber         = errors.New("CPF number input is not valid")

--- a/example/example.go
+++ b/example/example.go
@@ -73,6 +73,24 @@ func main() {
 	// ------------------------------------------------------------------------------------------------
 
 	{
+		// Generates a new alphanumeric CNPJ number (IN RFB n° 2.229/2024) in the string format XX.XXX.XXX/XXXX-XX
+		cnpjNumber := brazil.RandomAlphanumericCNPJNumber(true)
+
+		// Creates a new CNPJ struct
+		cnpj, err := brazil.ParseAlphanumericCNPJ(cnpjNumber)
+		if err != nil {
+			log.Println(err)
+			log.Println(cnpjNumber)
+			return
+		}
+
+		// Returns CNPJ number
+		log.Println(cnpj.Number(true))
+	}
+
+	// ------------------------------------------------------------------------------------------------
+
+	{
 		// Generates a new PIS number in the string format XXX.XXXXX.XX-X
 		pisNumber := brazil.RandomPISNumber(true)
 
@@ -186,6 +204,24 @@ func main() {
 
 		// Creates a new CNPJ struct
 		cnpj, err := brazil.Validate("cnpj", cnpjNumber, true)
+		if err != nil {
+			log.Println(err)
+			log.Println(cnpjNumber)
+			return
+		}
+
+		// Returns CNPJ number
+		log.Println(cnpj)
+	}
+
+	// ------------------------------------------------------------------------------------------------
+
+	{
+		// Generates a new alphanumeric CNPJ number (IN RFB n° 2.229/2024) in the string format XX.XXX.XXX/XXXX-XX
+		cnpjNumber := brazil.RandomAlphanumericCNPJNumber(true)
+
+		// Creates a new CNPJ struct
+		cnpj, err := brazil.Validate("alphanumericCnpj", cnpjNumber, true)
 		if err != nil {
 			log.Println(err)
 			log.Println(cnpjNumber)

--- a/handler_validation.go
+++ b/handler_validation.go
@@ -7,19 +7,27 @@ import (
 type documentType string
 
 const (
-	CNPJ             documentType = "cnpj"
-	CPF              documentType = "cpf"
-	MOBILE           documentType = "mobile"
-	PIS              documentType = "pis"
-	SUS              documentType = "sus"
-	TITULO_ELEITORAL documentType = "tituloEleitoral"
-	CERTIDAO         documentType = "certidao"
+	CNPJ              documentType = "cnpj"
+	ALPHANUMERIC_CNPJ documentType = "alphanumericCnpj"
+	CPF               documentType = "cpf"
+	MOBILE            documentType = "mobile"
+	PIS               documentType = "pis"
+	SUS               documentType = "sus"
+	TITULO_ELEITORAL  documentType = "tituloEleitoral"
+	CERTIDAO          documentType = "certidao"
 )
 
 func Validate(t documentType, number string, mask bool) (string, error) {
 	switch t {
 	case CNPJ:
 		cnpj, err := ParseCNPJ(number)
+		if err != nil {
+			return "", err
+		}
+		return cnpj.Number(mask), err
+
+	case ALPHANUMERIC_CNPJ:
+		cnpj, err := ParseAlphanumericCNPJ(number)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
## Summary

Closes #18

Instrução Normativa RFB n° 2.229/2024 introduces the alphanumeric CNPJ format, in effect since July 2026: positions 0-11 accept `0-9`/`A-Z` while the check digits (positions 12-13) remain numeric.

This PR adds support for that format while keeping the existing numeric API untouched:

- **`ParseAlphanumericCNPJ`** (new file `cnpj_alphanumeric.go`): validates alphanumeric CNPJs using mod 11 with character value = `ASCII(char) - 48` (`'0'→0` … `'9'→9`, `'A'→17` … `'Z'→42`) and the same weights as the numeric format. Strips mask characters (`.`, `/`, `-`), normalizes lowercase to uppercase, rejects illegal characters, letters in the check-digit positions, and CNPJs with all 14 characters equal. Legacy numeric CNPJs are accepted (the alphanumeric algorithm is a superset of the numeric one).
- **`RandomAlphanumericCNPJNumber`**: generates valid alphanumeric CNPJs, mirroring `RandomCNPJNumber`.
- **New errors**: `ErrInvalidCNPJCharacter`, `ErrRepeatedCNPJNumber`.
- **`Validate` handler**: new `ALPHANUMERIC_CNPJ` (`"alphanumericCnpj"`) document type.
- Tests (GoConvey, same structure as the existing suites), usage examples and README updated.

`ParseCNPJ` and `RandomCNPJNumber` are unchanged — fully backward compatible.

## Test plan

- `go test ./...` — full suite green, including the pre-existing CNPJ tests
- New `TestParseAlphanumericCNPJ` covers: valid alphanumeric (`12ABC345000188`), masked input (`12.ABC.345/0001-88`), lowercase normalization, legacy numeric (`12345678000195`), wrong check digits, all-equal characters (`00000000000000`), illegal character (`12@BC345000188`), letter in check-digit position, and wrong length
- Check digits of the reference vector verified by hand against the IN RFB 2.229/2024 algorithm

🤖 Generated with [Claude Code](https://claude.com/claude-code)